### PR TITLE
Add `separator` option

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -24,6 +24,12 @@ export interface ModuleOptions {
    * @default 'langDir'
    */
   outputDir?: string
+  /**
+   * String to use as the column separator for each row
+   *
+   * @default ','
+   */
+  separator?: string
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -38,6 +44,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     langDir: 'locales',
+    separator: ',',
     translationFileName: 'translations'
   },
   async setup(options, nuxt) {
@@ -57,7 +64,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (isNuxtDir) {
       try {
-        await generateLocales(csvFileFullPath, outputDir)
+        await generateLocales(csvFileFullPath, outputDir, options.separator)
       } catch (error) {
         logger.error(error)
       }
@@ -70,7 +77,7 @@ export default defineNuxtModule<ModuleOptions>({
       )
       if (path === csvFilePath) {
         try {
-          await generateLocales(csvFileFullPath, outputDir)
+          await generateLocales(csvFileFullPath, outputDir, options.separator)
         } catch (error) {
           logger.error(error)
         }


### PR DESCRIPTION
Add an option to specify a different separator inside CSV files. Related to #10.