### PR TITLE
Add `separator` parameter to `generateLocales`

### DIFF
--- a/src/generateLocales.ts
+++ b/src/generateLocales.ts
@@ -8,7 +8,8 @@ interface ColumnData {
 
 function generateLocales(
   csvFilePath: string,
-  outputDir: string
+  outputDir: string,
+  separator: string
 ): Promise<void> {
   logger.info('Generating translations...')
 
@@ -28,7 +29,7 @@ function generateLocales(
 
   return new Promise((resolve, reject) => {
     fs.createReadStream(csvFilePath)
-      .pipe(csv({ skipComments: true }))
+      .pipe(csv({ separator, skipComments: true }))
       .on('data', (row) => processRow(row))
       .on('end', () => {
         // Sort the keys alphabetically


### PR DESCRIPTION
Add `separator` parameter to the main function and its corresponding key/value to the `csv()` call.

Related to #10 and #11.