### PR TITLE
Add support for nuxt-seo's `nuxtSiteConfig` translation object

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,31 @@ This will generate a CSV file that looks like this:
 
 </details>
 
+## Special keys
+
+You can specify the optional `NUXT_SITE_CONFIG_NAME` and `NUXT_SITE_CONFIG_DESCRIPTION` keys in order to take advantage of the special `nuxtSiteConfig` [i18n translation object](https://nuxtseo.com/site-config/integrations/i18n#usage). Specifying any of those keys will include them inside that object when the JSON text is rendered out.
+
+source:
+
+```csv
+Key,'en-US','es-MX'
+TEST_KEY,'Test key','Llave de prueba'
+NUXT_SITE_CONFIG_NAME,'Site name','Nombre del sitio'
+NUXT_SITE_CONFIG_DESCRIPTION,'Site description','Descripción del sitio'
+```
+becomes (`en-US`):
+
+```json
+{
+  "TEST_KEY": "Test key",
+  "nuxtSiteConfig": {
+    "name": "Site name",
+    "description": "Site description"
+  }
+}
+
+```
+
 ## Options
 
 ```ts

--- a/src/generateLocales.ts
+++ b/src/generateLocales.ts
@@ -2,21 +2,18 @@ import fs from 'node:fs'
 import csv from 'csv-parser'
 import logger from './logger'
 
+interface ColumnData {
+  [key: string]: string
+}
+
 interface LocaleTranslations {
-  [key: string]: string | {
-    description?: string
-    name?: string
-  }
+  [key: string]: string | { description?: string, name?: string }
 }
 
 const REGEX_SITE_CONFIG: RegExp = /^NUXT_SITE_CONFIG_(DESCRIPTION|NAME)$/
 const SITE_CONFIG_KEY: string = 'nuxtSiteConfig'
 
-function generateLocales(
-  csvFilePath: string,
-  outputDir: string,
-  separator: string
-): Promise<void> {
+function generateLocales(csvFilePath: string, outputDir: string, separator: string): Promise<void> {
   logger.info('Generating translations...')
   const columns: Record<string, LocaleTranslations> = {}
   
@@ -38,8 +35,8 @@ function generateLocales(
           }
 
           const configKey: string = key.replace('NUXT_SITE_CONFIG_', '').toLowerCase()
-          if (!columns[column][SITE_CONFIG_KEY]) columns[column][SITE_CONFIG_KEY] = {} as { [key: string]: string }
-          (columns[column][SITE_CONFIG_KEY] as { [key: string]: string })[configKey] = value
+          if (!columns[column][SITE_CONFIG_KEY]) columns[column][SITE_CONFIG_KEY] = {} as ColumnData
+          (columns[column][SITE_CONFIG_KEY] as ColumnData)[configKey] = value
         })
       })
       .on('end', (): void => {

--- a/src/generateLocales.ts
+++ b/src/generateLocales.ts
@@ -40,6 +40,15 @@ function generateLocales(csvFilePath: string, outputDir: string, separator: stri
         })
       })
       .on('end', (): void => {
+        // Sort keys alphabetically
+        Object.keys(columns).forEach((header: string): void => {
+          columns[header] = Object.fromEntries(
+            Object.entries(columns[header]).sort(([a], [b]): number =>
+              a.localeCompare(b)
+            )
+          )
+        })
+
         Object.keys(columns).forEach((header: string): void => {
           const outputPath: string = `${outputDir}/${header}.json`
           fs.writeFileSync(outputPath, JSON.stringify(columns[header], null, 2), 'utf-8')

--- a/src/generateLocales.ts
+++ b/src/generateLocales.ts
@@ -3,10 +3,6 @@ import csv from 'csv-parser'
 import logger from './logger'
 
 interface ColumnData {
-  [key: string]: string
-}
-
-interface LocaleTranslations {
   [key: string]: string | { description?: string, name?: string }
 }
 
@@ -14,12 +10,13 @@ const REGEX_SITE_CONFIG: RegExp = /^NUXT_SITE_CONFIG_(DESCRIPTION|NAME)$/
 const SITE_CONFIG_KEY: string = 'nuxtSiteConfig'
 
 function generateLocales(csvFilePath: string, outputDir: string, separator: string): Promise<void> {
-  logger.info('Generating translations...')
-  const columns: Record<string, LocaleTranslations> = {}
+  logger.info('Generating translations…')
+  const columns: Record<string, ColumnData> = {}
   
   return new Promise((resolve, reject): void => {
     fs.createReadStream(csvFilePath)
       .pipe(csv({ separator, skipComments: true }))
+
       .on('data', (row: Record<string, string>): void => {
         const key: string = row.Key.trim()
 
@@ -27,18 +24,21 @@ function generateLocales(csvFilePath: string, outputDir: string, separator: stri
           value = (value as string).trim()
 
           if (column === 'Key' || value.length === 0) return
-          if (!columns[column]) columns[column] = {} as LocaleTranslations
+          if (!columns[column]) columns[column] = {} as ColumnData
 
           if (!REGEX_SITE_CONFIG.test(key)) {
             columns[column][key] = value
             return
           }
 
+          // Handle special site config keys
+          // @see https://nuxtseo.com/site-config/integrations/i18n#usage
           const configKey: string = key.replace('NUXT_SITE_CONFIG_', '').toLowerCase()
           if (!columns[column][SITE_CONFIG_KEY]) columns[column][SITE_CONFIG_KEY] = {} as ColumnData
           (columns[column][SITE_CONFIG_KEY] as ColumnData)[configKey] = value
         })
       })
+
       .on('end', (): void => {
         // Sort keys alphabetically
         Object.keys(columns).forEach((header: string): void => {
@@ -49,14 +49,19 @@ function generateLocales(csvFilePath: string, outputDir: string, separator: stri
           )
         })
 
+        // Generate a JSON file for each column
         Object.keys(columns).forEach((header: string): void => {
-          const outputPath: string = `${outputDir}/${header}.json`
-          fs.writeFileSync(outputPath, JSON.stringify(columns[header], null, 2), 'utf-8')
+          fs.writeFileSync(
+            `${outputDir}/${header}.json`,
+            JSON.stringify(columns[header], null, 2),
+            'utf-8'
+          )
         })
 
         logger.success('Translations generated successfully')
         resolve()
       })
+
       .on('error', (error: Error): void => reject(error))
   })
 }


### PR DESCRIPTION
## Special keys

You can specify the optional `NUXT_SITE_CONFIG_NAME` and `NUXT_SITE_CONFIG_DESCRIPTION` keys in order to take advantage of the special `nuxtSiteConfig` [i18n translation object](https://nuxtseo.com/site-config/integrations/i18n#usage). Specifying any of those keys will include them inside that object when the JSON text is rendered out.

source:

```csv
Key,'en-US','es-MX'
TEST_KEY,'Test key','Llave de prueba'
NUXT_SITE_CONFIG_NAME,'Site name','Nombre del sitio'
NUXT_SITE_CONFIG_DESCRIPTION,'Site description','Descripción del sitio'
```
becomes (`en-US`):

```json
{
  "TEST_KEY": "Test key",
  "nuxtSiteConfig": {
    "description": "Site description",
    "name": "Site name"
  }
}
```

`es-MX`:
```json
{
  "TEST_KEY": "Llave de prueba",
  "nuxtSiteConfig": {
    "description": "Descripción del sitio",
    "name": "Nombre del sitio"
  }
}
```